### PR TITLE
Validate project name

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,9 @@ cookiecutter templates/basic -o projects
 | There are more templates in the `templates` directory depending on the requirements of your project. |
 
 Answer the project setup questions:
+
 ```
-project_name: my_project          # replace this with your project name; project name cannot contain a hyphen
+project_name: my_project          # replace this with your project name (can only contain alphanumeric characters, `.`, and `_`)
 project_author: foobar            # replace this with your name
 github_username: my_username      # replace this with your github username
 description: project description  # optional

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ cookiecutter templates/basic -o projects
 
 Answer the project setup questions:
 ```
-project_name: my_project          # replace this with your project name; project name shouldn't have hyphens
+project_name: my_project          # replace this with your project name; project name cannot contain a hyphen
 project_author: foobar            # replace this with your name
 github_username: my_username      # replace this with your github username
 description: project description  # optional

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ cookiecutter templates/basic -o projects
 
 Answer the project setup questions:
 ```
-project_name: my_project          # replace this with your project name
+project_name: my_project          # replace this with your project name; project name shouldn't have hyphens
 project_author: foobar            # replace this with your name
 github_username: my_username      # replace this with your github username
 description: project description  # optional

--- a/templates/basic/hooks/pre_gen_project.py
+++ b/templates/basic/hooks/pre_gen_project.py
@@ -1,9 +1,10 @@
+import re
 import sys
+
+PROJECT_NAME_REGEX = "^[a-zA-Z0-9._]$"
 
 project_name = '{{ cookiecutter.project_name }}'
 
-if "-" in project_name:
-    print("ERROR: Project name cannot contain '-'.")
-
-    # exits with status 1 to indicate failure
+if not re.match(PROJECT_NAME_REGEX, project_name):
+    print(f"ERROR: Project name is invalid. Must match the expression {PROJECT_NAME_REGEX}")
     sys.exit(1)

--- a/templates/basic/hooks/pre_gen_project.py
+++ b/templates/basic/hooks/pre_gen_project.py
@@ -1,0 +1,9 @@
+import sys
+
+project_name = '{{ cookiecutter.project_name }}'
+
+if "-" in project_name:
+    print("ERROR: Project name cannot contain '-'.")
+
+    # exits with status 1 to indicate failure
+    sys.exit(1)


### PR DESCRIPTION
Project names shouldn't have hyphens as `pyflyte --pkgs` command doesn't work if there's a hyphen. Hence, added a hook to validate the name before creating a project.

More context: https://flyte-org.slack.com/archives/CP2HDHKE1/p1645553316909929